### PR TITLE
Fix unrecognized type warning

### DIFF
--- a/lib/activerecord-multirange/adapter.rb
+++ b/lib/activerecord-multirange/adapter.rb
@@ -16,13 +16,13 @@ module Activerecord
         initializer =
           ::ActiveRecord::ConnectionAdapters::PostgreSQLAdapter::OID::TypeMapInitializer
             .new(type_map)
-        
+
         # Query for multirange types and their corresponding base types (not range types)
         # We need to get the range's subtype (e.g., date) not the range type itself
         query = <<-QUERY.squish
-          SELECT m.oid, m.typname, m.typelem, m.typdelim, m.typinput, 
+          SELECT m.oid, m.typname, m.typelem, m.typdelim, m.typinput::varchar,
                  pr.rngsubtype, m.typtype, m.typbasetype
-          FROM pg_type m 
+          FROM pg_type m
           JOIN pg_type r ON REPLACE(m.typname, 'multirange', 'range') = r.typname
           JOIN pg_range pr ON r.oid = pr.rngtypid
           WHERE m.typtype = 'm';


### PR DESCRIPTION
the column `typinput` is of type `regproc` which is a special kind of string that represents function names (see
https://www.postgresql.org/docs/current/datatype-oid.html).

But this type is not recognized by rails out of the box, and so it is triggering a warning:

```
unknown OID 24: failed to recognize type of 'typinput'. It will be
treated as String.
```

Instead of letting Rails infer that it should treat that type as a string, let's coerce it to a string directly in the query. This makes the warning go away without any change in functionality.