### PR TITLE
Fix unrecognized type warning (redux)

### DIFF
--- a/lib/activerecord-multirange/adapter.rb
+++ b/lib/activerecord-multirange/adapter.rb
@@ -20,9 +20,9 @@ module Activerecord
         # Query for multirange types and their corresponding base types (not range types)
         # We need to get the range's subtype (e.g., date) not the range type itself
         query = <<-QUERY.squish
-          SELECT m.oid, m.typname, m.typelem, m.typdelim, m.typinput, 
+          SELECT m.oid, m.typname, m.typelem, m.typdelim, m.typinput::varchar,
                  pr.rngsubtype, m.typtype, m.typbasetype
-          FROM pg_type m 
+          FROM pg_type m
           JOIN pg_range pr ON m.oid = pr.rngmultitypid
           WHERE m.typtype = 'm';
         QUERY


### PR DESCRIPTION
this is a repeat of this PR:
https://github.com/gustavowt/activerecord-multirange/pull/7

the bug was re-introduced in this recent commit: https://github.com/gustavowt/activerecord-multirange/commit/046c2d71bf5d8270e43feec2988591afd58e5e0c#diff-a606209ccfbdf04dbc20038a1e221a4b9cca608d2d658a54fae62cbea15ace44L23-L34